### PR TITLE
Fix typo in configure_file argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,7 +561,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/copy-headers.cmake "
   file(MAKE_DIRECTORY gsl)
   foreach (path ${GSL_HEADER_PATHS})
     get_filename_component(filename \${path} NAME)
-    configure_file(\${path} ${GSL_BINARY_DIR}/gsl/\${filename} COPY_ONLY)
+    configure_file(\${path} ${GSL_BINARY_DIR}/gsl/\${filename} COPYONLY)
   endforeach ()")
 
 add_custom_command(OUTPUT ${GSL_HEADERS}


### PR DESCRIPTION
This fixes the call to `configure_file` in the generated `copy_headers.cmake` file. It should be `COPYONLY` and not `COPY_ONLY`.