### PR TITLE
Fix warning about C99 inline functions + use configure_file in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,11 +514,12 @@ foreach (i RANGE ${length})
   string(REPLACE "<semi>" ";" line "${line}")
   set(CONFIG_OUT "${CONFIG_OUT}${line}")
 endforeach ()
-file(WRITE ${GSL_BINARY_DIR}/config.h
-"/* config.h.  Generated from config.h.in by configure.  */
-/* config.h.in.  Generated from configure.ac by autoheader.  */
+# file(WRITE ${GSL_BINARY_DIR}/config.h
+# "/* config.h.  Generated from config.h.in by configure.  */
+# /* config.h.in.  Generated from configure.ac by autoheader.  */
 
-${CONFIG_OUT}")
+# ${CONFIG_OUT}")
+configure_file(config.h.cmake.in ${GSL_BINARY_DIR}/config.h)
 
 include_directories(${GSL_BINARY_DIR} ${GSL_SOURCE_DIR})
 add_definitions(-DHAVE_CONFIG_H)

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -1,0 +1,1 @@
+@CONFIG_OUT@

--- a/gsl_inline.h
+++ b/gsl_inline.h
@@ -1,17 +1,17 @@
 /* gsl_inline.h
- * 
+ *
  * Copyright (C) 2008, 2009 Brian Gough
- * 
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or (at
  * your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
@@ -33,7 +33,7 @@
    errors on linking.  The 'inline' keyword on its own (without
    extern) has the same behavior as the original GNU 'extern inline'.
 
-   The C99 style is the default with -std=c99 in GCC 4.3.  
+   The C99 style is the default with -std=c99 in GCC 4.3.
 
    This header file allows either form of inline to be used by
    redefining the macros INLINE_DECL and INLINE_FUN.  These are used
@@ -43,12 +43,12 @@
 	#ifdef HAVE_INLINE
 	INLINE_FUN double gsl_foo (double x) { return x+1.0; } ;
         #endif
-   
+
 */
 
 #ifdef HAVE_INLINE
 #  if defined(__GNUC_STDC_INLINE__) || defined(GSL_C99_INLINE) || defined(HAVE_C99_INLINE)
-#    define INLINE_DECL inline  /* use C99 inline */
+#    define INLINE_DECL static inline /* use C99 inline */
 #    define INLINE_FUN static inline
 #  else
 #    define INLINE_DECL         /* use GNU extern inline */


### PR DESCRIPTION
Using `file(WRITE ...)` for files that are used as build input input is a bad idea, since everytime someone modifies the CMake scripts, those files will be re-generated (thus forcing to recompile the whole GSL). The correct approach is to use `configure_file()` which will not overwrite the destination file unless the content has changed.

I've also fixed a warning with the inline keyword in C99 mode, which was currently spilling tons of warnings about `function declared but not defined` (I think the compiler was considering the declaration and definition to be different functions).