### PR TITLE
Change use of CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR to build as sub-project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,7 +777,7 @@ if (GSL_INSTALL OR NOT DEFINED GSL_INSTALL)
     DESTINATION lib/cmake/${PACKAGE_NAME}-${PACKAGE_VERSION}
     NAMESPACE GSL:: )
   configure_package_config_file(
-    ${CMAKE_SOURCE_DIR}/cmake/${PACKAGE_NAME}-config.cmake.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PACKAGE_NAME}-config.cmake.in
     ${CMAKE_BINARY_DIR}/cmake/${PACKAGE_NAME}-config.cmake
     INSTALL_DESTINATION cmake/${PACKAGE_NAME} )
   write_basic_package_version_file(


### PR DESCRIPTION
We are starting to use AMPL GSL as a sub-module which we store in PROJECT_ROOT/ThirdParty/gsl

The use of CMAKE_SOURCE_DIR causes it to try to find the gsl-config.cmake-in file at the PROJECT_ROOT/cmake instead of PROJECT_ROOT/ThirdParty/gsl/cmake

By changing to use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR the file will be found inside the GSL submodule as expected.