### PR TITLE
Add a ARCHIVE DESTINATION in ampl/ to allow building static library

### DIFF
--- a/ampl/CMakeLists.txt
+++ b/ampl/CMakeLists.txt
@@ -19,6 +19,7 @@ macro(add_ampl_library name)
   # DESTINATION or ARCHIVE_DESTINATION because we don't want to import
   # libraries installed.
    install(TARGETS ${name} 
+    ARCHIVE DESTINATION ${AMPL_LIBRARY_DIR} 
     RUNTIME DESTINATION ${AMPL_LIBRARY_DIR} 
     LIBRARY DESTINATION ${AMPL_LIBRARY_DIR})
 endmacro()


### PR DESCRIPTION
On platforms without shared library support, CMake opts to build a static library with just a warning that the shared library cannot be built:
```
CMake Warning (dev) at ampl/CMakeLists.txt:14 (add_library):
  ADD_LIBRARY called with SHARED option but the target platform does not
  support dynamic linking.  Building a STATIC library instead.  This may lead
  to problems.

```
Later in the build, the lack of a static library destination causes CMake to fail. Providing an ARCHIVE DESTINATION solves this issue.

This change is applicable when compiling for environments with only static library support - I came across this issue while using the emscripten (http://emscripten.org) SDK to build GSL for a WASM target (which has very rudimentary dynamic linking support).

The issue can be reproduced as follows:

1) Install emscripten: https://emscripten.org/docs/getting_started/downloads.html

2) `$ emsdk-master/upstream/emscripten/emcmake cmake .`