### PR TITLE
Upstreaming Krita patches for Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ CMakeFiles
 build-*/
 gsl.def
 *.nupkg
+/.cache
+/.vscode
 /build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,7 @@ endif ()
 # Compiles the source code, runs the program and sets ${VAR} to 1 if the
 # return value is equal to ${RESULT}.
 macro(check_run_result SRC RESULT VAR)
+if (NOT ANDROID)
   set(SRC_FILE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/src.c)
   file(WRITE ${SRC_FILE} "${SRC}")
   try_run(RUN_RESULT COMPILE_RESULT ${CMAKE_BINARY_DIR} ${SRC_FILE}
@@ -452,6 +453,9 @@ macro(check_run_result SRC RESULT VAR)
   if (RUN_RESULT EQUAL ${RESULT})
     set(${VAR} 1)
   endif ()
+else()
+  set(${VAR} 1)
+endif()
 endmacro()
 
 # Check IEEE comparisons, whether "x != x" is true for NaNs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,11 +829,7 @@ foreach (dir ${HAVETOBUILD})
 endforeach ()
 
 if (BUILD_SHARED_LIBS)
-  include(CheckCCompilerFlag)
-  check_c_compiler_flag(-fPIC HAVE_FPIC)
-  if (HAVE_FPIC)
-    add_definitions(-fPIC)
-  endif ()
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   if (WIN32)
     # only needed for global variables that must be exported.  Exporting of
     # all functions is done with target property WINDOWS_EXPORT_ALL_SYMBOLS.
@@ -937,10 +933,10 @@ if (GSL_INSTALL OR NOT DEFINED GSL_INSTALL)
       lib/cmake/${PACKAGE_NAME}-${PACKAGE_VERSION} 
     COMPONENT gsl)
 endif ()
-if(NOT MSVC)
-    target_compile_options(gsl PRIVATE -fPIC)
+if(NOT WIN32)
+    set_target_properties(gsl PROPERTIES POSITION_INDEPENDENT_CODE ON)
     if(TARGET gslcblas)
-      target_compile_options(gslcblas PRIVATE -fPIC)
+      set_target_properties(gslcblas PROPERTIES POSITION_INDEPENDENT_CODE ON)
     endif()
 endif()
 

--- a/matrix/test_complex_source.c
+++ b/matrix/test_complex_source.c
@@ -18,6 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <config.h>
+#if HAVE_UNISTD_H
+  #include <unistd.h>
+#endif
+
 void FUNCTION (test, func) (const size_t M, const size_t N);
 void FUNCTION (test, ops) (const size_t P, const size_t Q);
 void FUNCTION (test, trap) (const size_t M, const size_t N);

--- a/matrix/test_source.c
+++ b/matrix/test_source.c
@@ -18,6 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <config.h>
+#if HAVE_UNISTD_H
+  #include <unistd.h>
+#endif
+
 void FUNCTION (test, func) (const size_t M, const size_t N);
 void FUNCTION (test, ops) (const size_t M, const size_t N);
 void FUNCTION (test, trap) (const size_t M, const size_t N);

--- a/vector/test_complex_source.c
+++ b/vector/test_complex_source.c
@@ -17,6 +17,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <config.h>
+#if HAVE_UNISTD_H
+  #include <unistd.h>
+#endif
+
 void FUNCTION (test, func) (size_t stride, size_t N);
 void FUNCTION (test, ops) (size_t stride1, size_t stride2, size_t N);
 void FUNCTION (test, file) (size_t stride, size_t N);

--- a/vector/test_source.c
+++ b/vector/test_source.c
@@ -17,6 +17,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <config.h>
+#if HAVE_UNISTD_H
+  #include <unistd.h>
+#endif
+
 void FUNCTION (test, func) (size_t stride, size_t N);
 void FUNCTION (test, ops) (size_t stride1, size_t stride2, size_t N);
 void FUNCTION (test, file) (size_t stride, size_t N);


### PR DESCRIPTION
👋 

These are the patches that we're running at Krita to use your version of GSL.

In particular, I'd like to call your attention to the changes to `-fPIC`, as this flag is not accepted by MSYS Clang under Windows. Moreover, it's taken care of automatically by CMake once  `CMAKE_POSITION_INDEPENDENT_CODE` or the target property `POSITION_INDEPENDENT_CODE` is set. (This is a minor modification to the patch of @alvinhochun, but I have preserved his credit here.)

I also added a minor change to your gitignore pattern to remove the noise caused by clangd's IntelliSense under VS Code.

cc @vanyossi @sh-zam @alvinhochun