### PR TITLE
Include stddef.h for size_t in gsl_spmatrix.h

### DIFF
--- a/spmatrix/gsl_spmatrix.h
+++ b/spmatrix/gsl_spmatrix.h
@@ -1,6 +1,8 @@
 #ifndef __GSL_SPMATRIX_H__
 #define __GSL_SPMATRIX_H__
 
+#include <stddef.h>
+
 enum
 {
   GSL_SPMATRIX_COO = 0, /* coordinate/triplet representation */


### PR DESCRIPTION
While building 3Depict 0.0.23 I got:
```
/usr/include/gsl/gsl_spmatrix.h:40:32: error: 'size_t' does not name a type
```
Seems like gel_spmatrix.h should include stddef.h to define that.