### PR TITLE
Fix wrong hessian order in amplgsl.cc and gsl-test.cc

### DIFF
--- a/ampl/src/amplgsl.cc
+++ b/ampl/src/amplgsl.cc
@@ -357,8 +357,8 @@ static double amplgsl_hypot3(arglist *al) {
       double dz2 = derivs[2] * derivs[2];
       hes[0] =  (dy2 + dz2) / hypot;
       hes[1] = -derivs[0] * derivs[1] / hypot;
-      hes[2] = -derivs[0] * derivs[2] / hypot;
-      hes[3] =  (dx2 + dz2) / hypot;
+      hes[2] =  (dx2 + dz2) / hypot;
+      hes[3] = -derivs[0] * derivs[2] / hypot;
       hes[4] = -derivs[1] * derivs[2] / hypot;
       hes[5] =  (dx2 + dy2) / hypot;
     }

--- a/ampl/test/gsl-test.cc
+++ b/ampl/test/gsl-test.cc
@@ -391,7 +391,7 @@ void GSLTest::CheckSecondDerivatives(F f, const Function &af,
         if (!gsl_isnan(d)) {
           unsigned ii = i, jj = j;
           if (ii > jj) std::swap(ii, jj);
-          unsigned hes_index = ii * (2 * num_args - ii - 1) / 2 + jj;
+          unsigned hes_index = ii + jj * (jj + 1) / 2;
           double actual_deriv = af(args, HES, use_deriv).hes(hes_index);
           if (!CheckDerivative(actual_deriv, d, error)) {
             std::cout << "Absolute tolerance of "


### PR DESCRIPTION
Currently, the hessian order in `amplgsl.cc` and `gsl-test.cc` do not accord with the instruction in `funcadd.h`: `In this case, the function should set al->hes[i + j*(j+1)/2] to the partial derivative of the function with respect to al->ra[i] and al->ra[j] for all 0 <= i <= j < al->nr.` and do not accord with the instruction in Page 19 of https://ampl.com/wp-content/uploads/Hooking-Your-Solver-to-AMPL-by-David-M.-Gay.pdf.

I already pull up a merge request in https://github.com/ampl/gsl/pull/75 but forgot to modify the hessian order in `gsl-test.cc` and the code was reverted by @fdabrandao . This new code also fixes the bug in `gsl-test.cc`. Could you review this code and merge it? Thanks again!