### PR TITLE
Remove redundant include directive

### DIFF
--- a/blas/blas.c
+++ b/blas/blas.c
@@ -25,7 +25,6 @@
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_cblas.h>
-#include <gsl/gsl_cblas.h>
 #include <gsl/gsl_blas_types.h>
 #include <gsl/gsl_blas.h>
 


### PR DESCRIPTION
This PR removes a duplicate #include <gsl/gsl_cblas.h> statement from blas/blas.c.

This change:
- Improves code readability
- Eliminates redundancy
- Follows C/C++ best practices
- No functional changes or risks
- Small but meaningful step towards better code quality