### PR TITLE
cholesky: triangular linear solver: gsl_linalg_cholesky_svx

### DIFF
--- a/linalg/cholesky.c
+++ b/linalg/cholesky.c
@@ -150,7 +150,7 @@ gsl_linalg_cholesky_svx (const gsl_matrix * LLT,
       gsl_blas_dtrsv (CblasLower, CblasNoTrans, CblasNonUnit, LLT, x);
 
       /* perform back-substitution, L^T x = c */
-      // gsl_blas_dtrsv (CblasLower, CblasTrans, CblasNonUnit, LLT, x);
+      /* gsl_blas_dtrsv (CblasLower, CblasTrans, CblasNonUnit, LLT, x);*/
 
       return GSL_SUCCESS;
     }

--- a/linalg/cholesky.c
+++ b/linalg/cholesky.c
@@ -145,12 +145,12 @@ gsl_linalg_cholesky_svx (const gsl_matrix * LLT,
       GSL_ERROR ("matrix size must match solution size", GSL_EBADLEN);
     }
   else
-    {
+    { 
       /* solve for c using forward-substitution, L c = b */
       gsl_blas_dtrsv (CblasLower, CblasNoTrans, CblasNonUnit, LLT, x);
 
       /* perform back-substitution, L^T x = c */
-      gsl_blas_dtrsv (CblasLower, CblasTrans, CblasNonUnit, LLT, x);
+      // gsl_blas_dtrsv (CblasLower, CblasTrans, CblasNonUnit, LLT, x);
 
       return GSL_SUCCESS;
     }


### PR DESCRIPTION
The `gsl_linalg_cholesky_svx` is an easy way to achieve the triangular linear solver for one output from cholesky decomposition and one vector. In this algorithm, we only need one forward substitution, while the backward substitution is only used for the context, where the user manually transposes the result from `gsl_linalg_cholesky_decomp`.