### PR TITLE
Support Windows MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,7 +342,7 @@ endif ()
 
 include(CheckLibraryExists)
 check_library_exists(m cos "" HAVE_LIBM)
-if (HAVE_LIBM)
+if (NOT MSVC AND HAVE_LIBM)
   set(CMAKE_REQUIRED_LIBRARIES m)
 endif ()
 


### PR DESCRIPTION
In MSVC, libm (`math.h`) is included by default. We do not need to link to it when `MSVC` is defined.